### PR TITLE
#2618 When `javaType` has not (or partially) been specified, try to determine the best matching constructor

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
+++ b/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 package org.apache.ibatis.builder;
 
+import java.lang.reflect.Constructor;
 import java.sql.ResultSet;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -25,6 +27,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.cache.decorators.LruCache;
@@ -467,4 +470,66 @@ public class MapperBuilderAssistant extends BaseBuilder {
     return javaType;
   }
 
+  /**
+   * Attempts to assign a {@code javaType} to result mappings when it has been omitted, this is done based on matching
+   * constructors of the specified {@code resultType}
+   *
+   * @param resultType
+   *          the result type of the object to be built
+   * @param resultMappings
+   *          the current mappings
+   *
+   * @return null if there are no missing javaType mappings, or if no suitable mapping could be determined
+   */
+  public List<ResultMapping> autoTypeResultMappingsForUnknownJavaTypes(Class<?> resultType,
+      List<ResultMapping> resultMappings) {
+    // check if we have any undefined java types present, and try to set them automatically
+    if (resultMappings.stream().noneMatch(resultMapping -> Object.class.equals(resultMapping.getJavaType()))) {
+      return null;
+    }
+
+    final List<List<Class<?>>> matchingConstructors = Arrays.stream(resultType.getDeclaredConstructors())
+        .map(Constructor::getParameterTypes).filter(parameters -> parameters.length == resultMappings.size())
+        .map(Arrays::asList).collect(Collectors.toList());
+
+    final List<Class<?>> typesToMatch = resultMappings.stream().map(ResultMapping::getJavaType)
+        .collect(Collectors.toList());
+
+    List<Class<?>> matchingTypes = null;
+
+    outer: for (final List<Class<?>> actualTypes : matchingConstructors) {
+      for (int j = 0; j < typesToMatch.size(); j++) {
+        final Class<?> type = typesToMatch.get(j);
+        // pre-filled a type, check if it matches the constructor
+        if (!Object.class.equals(type) && !type.equals(actualTypes.get(j))) {
+          continue outer;
+        }
+      }
+
+      if (matchingTypes != null) {
+        // multiple matches found, abort as we cannot reliably guess the correct one.
+        matchingTypes = null;
+        break;
+      }
+
+      matchingTypes = actualTypes;
+    }
+
+    if (matchingTypes == null) {
+      return null;
+    }
+
+    final List<ResultMapping> adjustedAutoTypeResultMappings = new ArrayList<>();
+    for (int i = 0; i < resultMappings.size(); i++) {
+      ResultMapping otherMapping = resultMappings.get(i);
+      Class<?> identifiedMatchingJavaType = matchingTypes.get(i);
+
+      // given that we selected a new java type, overwrite the currently
+      // selected type handler so it can get retrieved again from the registry
+      adjustedAutoTypeResultMappings
+          .add(new ResultMapping.Builder(otherMapping).javaType(identifiedMatchingJavaType).typeHandler(null).build());
+    }
+
+    return adjustedAutoTypeResultMappings;
+  }
 }

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -514,6 +515,7 @@ public class MapperAnnotationBuilder {
   }
 
   private void applyConstructorArgs(Arg[] args, Class<?> resultType, List<ResultMapping> resultMappings) {
+    final List<ResultMapping> mappings = new ArrayList<>();
     for (Arg arg : args) {
       List<ResultFlag> flags = new ArrayList<>();
       flags.add(ResultFlag.CONSTRUCTOR);
@@ -527,8 +529,11 @@ public class MapperAnnotationBuilder {
           nullOrEmpty(arg.column()), arg.javaType() == void.class ? null : arg.javaType(),
           arg.jdbcType() == JdbcType.UNDEFINED ? null : arg.jdbcType(), nullOrEmpty(arg.select()),
           nullOrEmpty(arg.resultMap()), null, nullOrEmpty(arg.columnPrefix()), typeHandler, flags, null, null, false);
-      resultMappings.add(resultMapping);
+      mappings.add(resultMapping);
     }
+
+    final List<ResultMapping> autoMappings = assistant.autoTypeResultMappingsForUnknownJavaTypes(resultType, mappings);
+    resultMappings.addAll(Objects.requireNonNullElse(autoMappings, mappings));
   }
 
   private String nullOrEmpty(String value) {

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 import org.apache.ibatis.builder.BaseBuilder;
@@ -267,14 +268,21 @@ public class XMLMapperBuilder extends BaseBuilder {
 
   private void processConstructorElement(XNode resultChild, Class<?> resultType, List<ResultMapping> resultMappings) {
     List<XNode> argChildren = resultChild.getChildren();
+
+    final List<ResultMapping> mappings = new ArrayList<>();
     for (XNode argChild : argChildren) {
       List<ResultFlag> flags = new ArrayList<>();
       flags.add(ResultFlag.CONSTRUCTOR);
       if ("idArg".equals(argChild.getName())) {
         flags.add(ResultFlag.ID);
       }
-      resultMappings.add(buildResultMappingFromContext(argChild, resultType, flags));
+
+      mappings.add(buildResultMappingFromContext(argChild, resultType, flags));
     }
+
+    final List<ResultMapping> autoMappings = builderAssistant.autoTypeResultMappingsForUnknownJavaTypes(resultType,
+        mappings);
+    resultMappings.addAll(Objects.requireNonNullElse(autoMappings, mappings));
   }
 
   private Discriminator processDiscriminatorElement(XNode context, Class<?> resultType,

--- a/src/main/java/org/apache/ibatis/mapping/ResultMap.java
+++ b/src/main/java/org/apache/ibatis/mapping/ResultMap.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,6 +15,13 @@
  */
 package org.apache.ibatis.mapping;
 
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.builder.BuilderException;
+import org.apache.ibatis.logging.Log;
+import org.apache.ibatis.logging.LogFactory;
+import org.apache.ibatis.reflection.ParamNameUtil;
+import org.apache.ibatis.session.Configuration;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
@@ -23,13 +30,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-
-import org.apache.ibatis.annotations.Param;
-import org.apache.ibatis.builder.BuilderException;
-import org.apache.ibatis.logging.Log;
-import org.apache.ibatis.logging.LogFactory;
-import org.apache.ibatis.reflection.ParamNameUtil;
-import org.apache.ibatis.session.Configuration;
 
 /**
  * @author Clinton Begin
@@ -137,7 +137,7 @@ public class ResultMap {
         if (actualArgNames == null) {
           throw new BuilderException("Error in result map '" + resultMap.id + "'. Failed to find a constructor in '"
               + resultMap.getType().getName() + "' with arg names " + constructorArgNames
-              + ". Note that 'javaType' is required when there is no writable property with the same name ('name' is optional, BTW). There might be more info in debug log.");
+              + ". Note that 'javaType' is required when there is ambiguous constructors or there is no writable property with the same name ('name' is optional, BTW). There might be more info in debug log.");
         }
         resultMap.constructorResultMappings.sort((o1, o2) -> {
           int paramIdx1 = actualArgNames.indexOf(o1.getProperty());

--- a/src/main/java/org/apache/ibatis/mapping/ResultMapping.java
+++ b/src/main/java/org/apache/ibatis/mapping/ResultMapping.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,15 +15,15 @@
  */
 package org.apache.ibatis.mapping;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author Clinton Begin
@@ -70,6 +70,24 @@ public class ResultMapping {
       resultMapping.flags = new ArrayList<>();
       resultMapping.composites = new ArrayList<>();
       resultMapping.lazy = configuration.isLazyLoadingEnabled();
+    }
+
+    public Builder(ResultMapping otherMapping) {
+      this(otherMapping.configuration, otherMapping.property);
+
+      resultMapping.flags.addAll(otherMapping.flags);
+      resultMapping.composites.addAll(otherMapping.composites);
+
+      resultMapping.column = otherMapping.column;
+      resultMapping.javaType = otherMapping.javaType;
+      resultMapping.jdbcType = otherMapping.jdbcType;
+      resultMapping.typeHandler = otherMapping.typeHandler;
+      resultMapping.nestedResultMapId = otherMapping.nestedResultMapId;
+      resultMapping.nestedQueryId = otherMapping.nestedQueryId;
+      resultMapping.notNullColumns = otherMapping.notNullColumns;
+      resultMapping.columnPrefix = otherMapping.columnPrefix;
+      resultMapping.resultSet = otherMapping.resultSet;
+      resultMapping.foreignColumn = otherMapping.foreignColumn;
     }
 
     public Builder javaType(Class<?> javaType) {
@@ -243,16 +261,8 @@ public class ResultMapping {
     return foreignColumn;
   }
 
-  public void setForeignColumn(String foreignColumn) {
-    this.foreignColumn = foreignColumn;
-  }
-
   public boolean isLazy() {
     return lazy;
-  }
-
-  public void setLazy(boolean lazy) {
-    this.lazy = lazy;
   }
 
   public boolean isSimple() {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -15,6 +15,20 @@
  */
 package org.apache.ibatis.session;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiFunction;
+
 import org.apache.ibatis.binding.MapperRegistry;
 import org.apache.ibatis.builder.CacheRefResolver;
 import org.apache.ibatis.builder.IncompleteElementException;
@@ -82,20 +96,6 @@ import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeAliasRegistry;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.BiFunction;
 
 /**
  * @author Clinton Begin

--- a/src/test/java/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/Account.java
+++ b/src/test/java/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/Account.java
@@ -1,0 +1,20 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor;
+
+public record Account(long accountId, String accountName, String accountType) {
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/Account2.java
+++ b/src/test/java/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/Account2.java
@@ -1,0 +1,23 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor;
+
+public record Account2(long accountId, String accountName, String accountType) {
+
+  public Account2(long accountId, String accountName, String accountType, String extraInfo) {
+    this(accountId, accountName, accountType);
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/Account3.java
+++ b/src/test/java/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/Account3.java
@@ -1,0 +1,27 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor;
+
+public record Account3(long accountId, String accountName, String accountType) {
+
+  public Account3(long accountId, int mismatch, String accountType) {
+    this(accountId, "MismatchedAccountI", accountType);
+  }
+
+  public Account3(long accountId, long mismatch, String accountType) {
+    this(accountId, "MismatchedAccountL", accountType);
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/AutoTypeFromNonAmbiguousConstructorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/AutoTypeFromNonAmbiguousConstructorTest.java
@@ -1,0 +1,106 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor;
+
+import java.io.Reader;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class AutoTypeFromNonAmbiguousConstructorTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    try (Reader reader = Resources.getResourceAsReader(
+        "org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+        "org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/CreateDB.sql");
+  }
+
+  @Test
+  void testNormalCaseWhereAllTypesAreProvided() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Account account = mapper.getAccountNonAmbiguous(1);
+      Assertions.assertThat(account).isNotNull();
+      Assertions.assertThat(account.accountId()).isEqualTo(1);
+      Assertions.assertThat(account.accountName()).isEqualTo("Account 1");
+      Assertions.assertThat(account.accountType()).isEqualTo("Current");
+    }
+  }
+
+  @Test
+  void testNoTypesAreProvidedAndUsesAutoType() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Account account = mapper.getAccountJavaTypesMissing(1);
+      Assertions.assertThat(account).isNotNull();
+      Assertions.assertThat(account.accountId()).isEqualTo(1);
+      Assertions.assertThat(account.accountName()).isEqualTo("Account 1");
+      Assertions.assertThat(account.accountType()).isEqualTo("Current");
+
+      Mapper1 mapper1 = sqlSession.getMapper(Mapper1.class);
+      Account account1 = mapper1.getAccountJavaTypesMissing(1);
+      Assertions.assertThat(account1).isNotNull();
+      Assertions.assertThat(account1.accountId()).isEqualTo(1);
+      Assertions.assertThat(account1.accountName()).isEqualTo("Account 1");
+      Assertions.assertThat(account1.accountType()).isEqualTo("Current");
+    }
+  }
+
+  @Test
+  void testSucceedsWhenConstructorWithMoreTypesAreFound() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Account2 account = mapper.getAccountExtraParameter(1);
+      Assertions.assertThat(account).isNotNull();
+      Assertions.assertThat(account.accountId()).isEqualTo(1);
+      Assertions.assertThat(account.accountName()).isEqualTo("Account 1");
+      Assertions.assertThat(account.accountType()).isEqualTo("Current");
+    }
+  }
+
+  @Test
+  void testChoosesCorrectConstructorWhenPartialTypesAreProvided() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Account3 account = mapper.getAccountPartialTypesProvided(1);
+      Assertions.assertThat(account).isNotNull();
+      Assertions.assertThat(account.accountId()).isEqualTo(1);
+      Assertions.assertThat(account.accountName()).isEqualTo("Account 1");
+      Assertions.assertThat(account.accountType()).isEqualTo("Current");
+
+      Mapper1 mapper1 = sqlSession.getMapper(Mapper1.class);
+      Account3 account1 = mapper1.getAccountPartialTypesProvided(1);
+      Assertions.assertThat(account1).isNotNull();
+      Assertions.assertThat(account1.accountId()).isEqualTo(1);
+      Assertions.assertThat(account1.accountName()).isEqualTo("Account 1");
+      Assertions.assertThat(account1.accountType()).isEqualTo("Current");
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/Mapper.java
@@ -1,0 +1,28 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor;
+
+public interface Mapper {
+
+  Account getAccountNonAmbiguous(long id);
+
+  Account getAccountJavaTypesMissing(long id);
+
+  Account2 getAccountExtraParameter(long id);
+
+  Account3 getAccountPartialTypesProvided(long id);
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/Mapper1.java
+++ b/src/test/java/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/Mapper1.java
@@ -1,0 +1,35 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor;
+
+import org.apache.ibatis.annotations.Arg;
+import org.apache.ibatis.annotations.ConstructorArgs;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface Mapper1 {
+
+  String SELECT_SQL = "select a.id, a.name, a.type from account a where a.id = #{id}";
+
+  @ConstructorArgs({ @Arg(column = "id"), @Arg(column = "name"), @Arg(column = "type"), })
+  @Select(SELECT_SQL)
+  Account getAccountJavaTypesMissing(long id);
+
+  @ConstructorArgs({ @Arg(column = "id"), @Arg(column = "name", javaType = String.class), @Arg(column = "type"), })
+  @Select(SELECT_SQL)
+  Account3 getAccountPartialTypesProvided(long id);
+}

--- a/src/test/resources/org/apache/ibatis/immutable/ImmutableBlogMapper.xml
+++ b/src/test/resources/org/apache/ibatis/immutable/ImmutableBlogMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2024 the original author or authors.
+       Copyright 2009-2025 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,10 +24,10 @@
 
     <resultMap id="immutableBlogResultMap" type="org.apache.ibatis.domain.blog.immutable.ImmutableBlog">
         <constructor>
-            <idArg column="id" javaType="_int"/>
-            <arg column="title" javaType="java.lang.String"/>
-            <arg javaType="org.apache.ibatis.domain.blog.immutable.ImmutableAuthor" resultMap="immutableAuthorResultMap" columnPrefix="author_"/>
-            <arg javaType="java.util.List" resultMap="immutablePostResultMap" columnPrefix="post_" />
+            <idArg column="id"/>
+            <arg column="title" />
+            <arg resultMap="immutableAuthorResultMap" columnPrefix="author_"/>
+            <arg resultMap="immutablePostResultMap" columnPrefix="post_" />
         </constructor>
     </resultMap>
 
@@ -38,7 +38,7 @@
             <arg column="password" javaType="String"/>
             <arg column="email" javaType="String"/>
             <arg column="bio" javaType="String"/>
-            <arg column="favorite_section" javaType="org.apache.ibatis.domain.blog.Section"/>
+            <arg column="favorite_section"/>
         </constructor>
     </resultMap>
 

--- a/src/test/resources/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/CreateDB.sql
+++ b/src/test/resources/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/CreateDB.sql
@@ -1,0 +1,26 @@
+--
+--    Copyright 2009-2025 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       https://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table account if exists;
+
+create table account (
+  id int,
+  name varchar(20),
+  type varchar(20)
+);
+
+insert into account (id, name, type) values
+(1, 'Account 1', 'Current');

--- a/src/test/resources/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/Mapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/Mapper.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2025 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor.Mapper">
+
+    <resultMap id="nonAmbiguousAccountRM" type="org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor.Account">
+        <constructor>
+            <idArg name="accountId" column="id" javaType="_long"/>
+            <arg name="accountName" column="name" javaType="java.lang.String"/>
+            <arg name="accountType" column="type" javaType="java.lang.String"/>
+        </constructor>
+    </resultMap>
+
+    <resultMap id="accountRM" type="org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor.Account">
+        <constructor>
+            <idArg name="accountId" column="id"/>
+            <arg name="accountName" column="name"/>
+            <arg name="accountType" column="type"/>
+        </constructor>
+    </resultMap>
+
+    <resultMap id="account2RM" type="org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor.Account2">
+        <constructor>
+            <idArg name="accountId" column="id"/>
+            <arg name="accountName" column="name"/>
+            <arg name="accountType" column="type"/>
+        </constructor>
+    </resultMap>
+
+    <resultMap id="account3RM" type="org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor.Account3">
+        <constructor>
+            <idArg name="accountId" column="id"/>
+            <arg name="accountName" column="name" javaType="java.lang.String" />
+            <arg name="accountType" column="type"/>
+        </constructor>
+    </resultMap>
+
+    <sql id="accountSelect">
+        select a.id
+          , a.name
+          , a.type
+        from account a
+          where a.id = #{id}
+    </sql>
+
+    <select id="getAccountNonAmbiguous" resultMap="nonAmbiguousAccountRM">
+        <include refid="accountSelect"/>
+    </select>
+
+    <select id="getAccountJavaTypesMissing" resultMap="accountRM">
+        <include refid="accountSelect"/>
+    </select>
+
+    <select id="getAccountExtraParameter" resultMap="account2RM">
+        <include refid="accountSelect"/>
+    </select>
+
+    <select id="getAccountPartialTypesProvided" resultMap="account3RM">
+        <include refid="accountSelect"/>
+    </select>
+</mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/mybatis-config.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/auto_type_from_non_ambiguous_constructor/mybatis-config.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2025 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value=""/>
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="org.hsqldb.jdbcDriver"/>
+                <property name="url"
+                          value="jdbc:hsqldb:mem:argNameBasedConstructorAutoMapping"/>
+                <property name="username" value="sa"/>
+            </dataSource>
+        </environment>
+    </environments>
+
+    <mappers>
+        <mapper class="org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor.Mapper"/>
+        <mapper class="org.apache.ibatis.submitted.auto_type_from_non_ambiguous_constructor.Mapper1"/>
+    </mappers>
+</configuration>


### PR DESCRIPTION
- falls back to current behaviour if any ambiguity is detected
- remove setters from immutable `ResultMapping`
